### PR TITLE
v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,37 @@
 ## Usage
 
 Call from command line like this:
+
 ```
-> python -m palabras olvidar
-olvidar
-- (transitive) to forget (be forgotten by)
-- (reflexive, intransitive) to forget, elude, escape
-- (with de, reflexive, intransitive) to forget, to leave behind
+python -m palabras ser
+```
+
+```
+Verb: ser (first-person singular present soy, first-person singular preterite fui, past participle sido)
+- to be (essentially or identified as)
+- to be (in the passive voice sense)
+- to exist; to occur
+
+Noun: ser m (plural seres)
+- a being, organism
+- nature, essence
+- value, worth
+```
+
+For more compact output:
+
+```
+python -m palabras ser --compact
+```
+
+```
+ser
+- to be (essentially or identified as)
+- to be (in the passive voice sense)
+- to exist; to occur
+- a being, organism
+- nature, essence
+- value, worth
 ```
 
 ## Install
@@ -45,15 +70,18 @@ pip install -e '.[test]'
 
 ### Checks
 
-Run tests:
+Run tests, linter, and type checks:
 
 ```
 pytest --cov --cov-report=term-missing
-```
-
-All tests should pass and coverage should be 100%.
-
-Run type checks:
-```
+flake8
 mypy palabras --ignore-missing-imports
 ```
+
+... or in one go:
+
+```
+tox
+```
+
+All checks should pass and test coverage should be 100% of lines.

--- a/palabras/__init__.py
+++ b/palabras/__init__.py
@@ -1,3 +1,3 @@
 """(WIP) Look up Spanish words on Wiktionary"""
 
-__version__ = '0.3.0-dev0'
+__version__ = '0.3.0'

--- a/palabras/__init__.py
+++ b/palabras/__init__.py
@@ -1,3 +1,3 @@
 """(WIP) Look up Spanish words on Wiktionary"""
 
-__version__ = '0.2.6'
+__version__ = '0.3.0-dev0'

--- a/palabras/cli.py
+++ b/palabras/cli.py
@@ -23,7 +23,8 @@ def main(args):
     args = parser.parse_args(args)
 
     try:
-        print(parse(WordInfo.from_search(args.word, revision=args.revision)))
+        word_info = WordInfo.from_search(args.word, revision=args.revision)
+        print(parse(word_info))
         return 0
     except (WiktionaryPageNotFound, WiktionarySectionNotFound) as exc:
         print(exc)
@@ -31,6 +32,4 @@ def main(args):
 
 
 def parse(word_info: WordInfo) -> str:
-    lines = [word_info.word]
-    lines += [f'- {ds}' for ds in word_info.definition_strings]
-    return '\n'.join(lines)
+    return word_info.compact_definition_str()

--- a/palabras/cli.py
+++ b/palabras/cli.py
@@ -20,16 +20,24 @@ def main(args):
         metavar='<n>',
         help='Wiktionary revision ID (from permalink)'
     )
+    parser.add_argument(
+        '--compact',
+        action='store_true',
+        help='List definitions for all parts of speech together'
+    )
     args = parser.parse_args(args)
 
     try:
         word_info = WordInfo.from_search(args.word, revision=args.revision)
-        print(parse(word_info))
+        print(parse(word_info, compact=args.compact))
         return 0
     except (WiktionaryPageNotFound, WiktionarySectionNotFound) as exc:
         print(exc)
         return 1
 
 
-def parse(word_info: WordInfo) -> str:
-    return word_info.compact_definition_str()
+def parse(word_info: WordInfo, compact: bool) -> str:
+    if compact:
+        return word_info.compact_definition_output()
+    else:
+        return word_info.definition_output()

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -214,6 +214,8 @@ class Subsection(WiktionaryPageSection):
         p = self.soup.p
         if p:
             return standardize_spaces(p.get_text().strip())
+        else:
+            return None
 
     def definitions(self) -> List[Definition]:
         """

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -84,7 +84,9 @@ class WiktionaryPage:
     def __contains__(self, other: str) -> bool:
         return other in str(self.soup)
 
-    def __eq__(self, other: WiktionaryPage) -> bool:
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return (
             self.word == other.word
             and self.revision == other.revision
@@ -149,7 +151,9 @@ class WiktionaryPageSection:
     def __contains__(self, other: str) -> bool:
         return other in str(self.soup)
 
-    def __eq__(self, other: WiktionaryPageSection):
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return (
             self.page == other.page
             and self.soup == other.soup

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -43,7 +43,12 @@ class WordInfo:
         Human-readable multiline string with all definitions listed under its
         corresponding part of speech
         """
-        raise NotImplementedError
+        outputs = []
+        for subsection in self.page_section.get_subsections():
+            if len(subsection.definitions()) > 0:
+                sub_output = f'{subsection.title}: {subsection.content_string()}'
+                outputs.append(sub_output)
+        return '\n\n'.join(outputs)
 
     def compact_definition_output(self) -> str:
         """
@@ -198,6 +203,7 @@ class Subsection(WiktionaryPageSection):
     def __repr__(self):
         return f'<{self.parent.page} → {self.parent.title!r} → {self.title!r}>'
 
+    # TODO remove
     def content_string(self) -> str:
         """
         Render contents as a human-readable string.
@@ -205,10 +211,9 @@ class Subsection(WiktionaryPageSection):
         lines = []
         p = self.soup.p
         if p:
-            lines.append(self.soup.p.get_text().strip())
+            lines.append(standardize_spaces(self.soup.p.get_text().strip()))
         for definition in self.definitions():
             lines.append(f'- {definition}')
-        lines.append('')  # add with empty line
         return '\n'.join(lines)
 
     def definitions(self) -> List[Definition]:
@@ -298,3 +303,8 @@ def get_siblings_until(element: PageElement,
         else:
             found.append(sibling)
     return found
+
+
+def standardize_spaces(s: str) -> str:
+    """Replace non-breaking space U+00a0 with a space"""
+    return s.replace('\u00a0', ' ')

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -31,12 +31,24 @@ class WordInfo:
         return cls(page_section=section)
 
     @property
+    def word(self):
+        return self.page_section.page.word
+
+    @property
     def definition_strings(self):
         return self.page_section.definitions()
 
-    def compact_definition_str(self) -> str:
+    def definition_output(self) -> str:
         """
-        Human-readable multiline string with word and all definitions listed one after one another
+        Human-readable multiline string with all definitions listed under its
+        corresponding part of speech
+        """
+        raise NotImplementedError
+
+    def compact_definition_output(self) -> str:
+        """
+        Human-readable multiline string with word and all definitions listed
+        one after one another
         """
         definitions_with_bullet = [
             f'- {dl}'
@@ -44,10 +56,6 @@ class WordInfo:
         ]
         lines = [self.word] + definitions_with_bullet
         return '\n'.join(lines)
-
-    @property
-    def word(self):
-        return self.page_section.page.word
 
 
 class WiktionaryPage:

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -34,6 +34,17 @@ class WordInfo:
     def definition_strings(self):
         return self.page_section.definitions()
 
+    def compact_definition_str(self) -> str:
+        """
+        Human-readable multiline string with word and all definitions listed one after one another
+        """
+        definitions_with_bullet = [
+            f'- {dl}'
+            for dl in self.page_section.definitions()
+        ]
+        lines = [self.word] + definitions_with_bullet
+        return '\n'.join(lines)
+
     @property
     def word(self):
         return self.page_section.page.word

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -338,16 +338,6 @@ def test_get_nonexistent_subsection(mocked_request_url_text):
         section.get_subsection('Nonexistent section')
 
 
-def test_adjective_subsection_content_string(mocked_request_url_text):
-    page = WiktionaryPage('empleado')
-    expected = dedent('''
-        empleado (feminine empleada, masculine plural empleados, feminine plural empleadas)
-        - employed
-    ''').lstrip()
-    ss = page.get_spanish_section().get_subsection('Adjective')
-    assert ss.content_string() == expected
-
-
 def test_get_heading_siblings_on_level():
     soup = BeautifulSoup(
         '<h1>tag 1</h1>'

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -152,8 +152,22 @@ def test_lookup_different_definitions_in_history(mocked_request_url_text):
         == expected_definitions_2
 
 
+@pytest.mark.xfail
 def test_cli(capsys: pytest.CaptureFixture, mocked_request_url_text):
     args = ['olvidar']
+    palabras.cli.main(args)
+    captured = capsys.readouterr()
+    expected = dedent('''
+        Verb: olvidar (first-person singular present olvido, first-person singular preterite olvidé, past participle olvidado)
+        - (transitive) to forget (be forgotten by)
+        - (reflexive, intransitive) to forget, elude, escape
+        - (with de, reflexive, intransitive) to forget, to leave behind
+    ''').lstrip()  # noqa: E501
+    assert captured.out == expected
+
+
+def test_cli_compact(capsys: pytest.CaptureFixture, mocked_request_url_text):
+    args = ['olvidar', '--compact']
     palabras.cli.main(args)
     captured = capsys.readouterr()
     expected = dedent('''
@@ -165,17 +179,18 @@ def test_cli(capsys: pytest.CaptureFixture, mocked_request_url_text):
     assert captured.out == expected
 
 
+@pytest.mark.xfail
 def test_cli_revision(capsys: pytest.CaptureFixture, mocked_request_url_text):
     args1 = ['olvidar', '-r', '62345284']
     args2 = ['olvidar', '--revision', '62345284']
     args3 = ['olvidar', '--revision=62345284']
 
     expected = dedent('''
-        olvidar
+        Verb: olvidar (first-person singular present olvido, first-person singular preterite olvidé, past participle olvidado)
         - to forget; to elude, escape (be forgotten by)
         - (reflexive) to forget
         - (reflexive) to leave behind
-    ''').lstrip()
+    ''').lstrip()  # noqa: E501
 
     for args in args1, args2, args3:
         exitcode = palabras.cli.main(args)
@@ -184,8 +199,28 @@ def test_cli_revision(capsys: pytest.CaptureFixture, mocked_request_url_text):
         assert exitcode == 0
 
 
+@pytest.mark.xfail
 def test_cli_ser(capsys: pytest.CaptureFixture, mocked_request_url_text):
     args = ['ser']
+    exitcode = palabras.cli.main(args)
+    captured = capsys.readouterr()
+    expected = dedent('''
+        Verb: ser (first-person singular present soy, first-person singular preterite fui, past participle sido)
+        - to be (essentially or identified as)
+        - to be (in the passive voice sense)
+        - to exist; to occur
+
+        Noun: ser m (plural seres)
+        - a being, organism
+        - nature, essence
+        - value, worth
+    ''').lstrip()  # noqa: E501
+    assert captured.out == expected
+    assert exitcode == 0
+
+
+def test_cli_ser_compact(capsys: pytest.CaptureFixture, mocked_request_url_text):
+    args = ['ser', '--compact']
     exitcode = palabras.cli.main(args)
     captured = capsys.readouterr()
     expected = dedent('''

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -67,6 +67,16 @@ def test_page_equalities(mocked_request_url_text):
     assert wp_with_revision != wp_with_revision_other
 
 
+def test_eqs_with_other_types(mocked_request_url_text):
+    word = 'olvidar'
+    page = WiktionaryPage(word)
+    section = page.get_section('Spanish')
+    wi = WordInfo(section)
+    assert page != 'foo'
+    assert section != 'foo'
+    assert wi != 'foo'
+
+
 def test_get_wiktionary_page_nonexistent(mocked_request_url_text):
     word = 'thispageaintexistent'
     with pytest.raises(palabras.core.WiktionaryPageNotFound):
@@ -152,7 +162,6 @@ def test_lookup_different_definitions_in_history(mocked_request_url_text):
         == expected_definitions_2
 
 
-@pytest.mark.xfail
 def test_cli(capsys: pytest.CaptureFixture, mocked_request_url_text):
     args = ['olvidar']
     palabras.cli.main(args)
@@ -179,7 +188,6 @@ def test_cli_compact(capsys: pytest.CaptureFixture, mocked_request_url_text):
     assert captured.out == expected
 
 
-@pytest.mark.xfail
 def test_cli_revision(capsys: pytest.CaptureFixture, mocked_request_url_text):
     args1 = ['olvidar', '-r', '62345284']
     args2 = ['olvidar', '--revision', '62345284']
@@ -199,7 +207,6 @@ def test_cli_revision(capsys: pytest.CaptureFixture, mocked_request_url_text):
         assert exitcode == 0
 
 
-@pytest.mark.xfail
 def test_cli_ser(capsys: pytest.CaptureFixture, mocked_request_url_text):
     args = ['ser']
     exitcode = palabras.cli.main(args)

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -48,6 +48,25 @@ def test_get_word_info_equals_but_is_not_word_info_from_search(mocked_request_ur
     assert wi1 is not wi2
 
 
+def test_page_equalities(mocked_request_url_text):
+    word = 'olvidar'
+    wp_1 = WiktionaryPage(word=word)
+    wp_2 = WiktionaryPage(word=word)
+
+    assert wp_1 == wp_2
+    assert wp_1 is not wp_2
+
+    revision_a = 62345284
+    revision_b = 66217360
+    wp_with_revision = WiktionaryPage(word=word, revision=revision_a)
+    wp_with_revision_same = WiktionaryPage(word=word, revision=revision_a)
+    wp_with_revision_other = WiktionaryPage(word=word, revision=revision_b)
+
+    assert wp_1 != wp_with_revision
+    assert wp_with_revision == wp_with_revision_same
+    assert wp_with_revision != wp_with_revision_other
+
+
 def test_get_wiktionary_page_nonexistent(mocked_request_url_text):
     word = 'thispageaintexistent'
     with pytest.raises(palabras.core.WiktionaryPageNotFound):


### PR DESCRIPTION
Separate compact and non-compact outputs + a bunch of internal changes.

New default output style:

```
❯ python -m palabras ser          
Verb: ser (first-person singular present soy, first-person singular preterite fui, past participle sido)
- to be (essentially or identified as)
- to be (in the passive voice sense)
- to exist; to occur

Noun: ser m (plural seres)
- a being, organism
- nature, essence
- value, worth
```

Compact output style:

```
❯ python -m palabras ser --compact    
ser
- to be (essentially or identified as)
- to be (in the passive voice sense)
- to exist; to occur
- a being, organism
- nature, essence
- value, worth
```