### PR TITLE
Define `palabras` command-line script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Call from command line like this:
 
 ```
-python -m palabras ser
+palabras ser
 ```
 
 ```
@@ -28,7 +28,7 @@ Noun: ser m (plural seres)
 For more compact output:
 
 ```
-python -m palabras ser --compact
+palabras ser --compact
 ```
 
 ```

--- a/palabras/__init__.py
+++ b/palabras/__init__.py
@@ -1,3 +1,3 @@
 """(WIP) Look up Spanish words on Wiktionary"""
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,11 @@ test = [
     "flake8",
 ]
 
+[project.scripts]
+palabras = "palabras:__main__"
 
 [project.urls]
 Home = "https://github.com/paavopere/palabras"
-
 
 # tox can be used locally
 # there is also a GitHub workflow in .github/workflows/test.yml that runs similar commands


### PR DESCRIPTION
You can now call `palabras` from command line (no need for `python -m palabras`)