### PR TITLE
v0.4.2: parse conjugation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install -e '.[test]'
     - name: pytest
       run: |
-        pytest --cov --cov-report=term-missing --doctest-modules
+        pytest
     - name: mypy
       run: |
         mypy palabras --ignore-missing-imports

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install -e '.[test]'
 Run tests, linter, and type checks:
 
 ```
-pytest --cov --cov-report=term-missing
+pytest
 flake8
 mypy palabras --ignore-missing-imports
 ```

--- a/palabras/__init__.py
+++ b/palabras/__init__.py
@@ -1,3 +1,3 @@
 """(WIP) Look up Spanish words on Wiktionary"""
 
-__version__ = '0.4.2-dev0'
+__version__ = '0.4.2'

--- a/palabras/__init__.py
+++ b/palabras/__init__.py
@@ -1,3 +1,3 @@
 """(WIP) Look up Spanish words on Wiktionary"""
 
-__version__ = '0.4.1'
+__version__ = '0.4.2-dev0'

--- a/palabras/cli.py
+++ b/palabras/cli.py
@@ -10,35 +10,25 @@ def main(args):
     parser = argparse.ArgumentParser(
         prog='palabras',
         description='Look up a word',
-        formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=50)
+        formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=50),
+    )
+    parser.add_argument('word', metavar='<word>', type=str, help='A word to look up')
+    parser.add_argument(
+        '-V', '--version', action='version', version=f'%(prog)s {__version__}'
     )
     parser.add_argument(
-        'word',
-        metavar='<word>',
-        type=str,
-        help='A word to look up'
-    )
-    parser.add_argument(
-        '-V', '--version',
-        action='version',
-        version=f'%(prog)s {__version__}'
-    )
-    parser.add_argument(
-        '-r', '--revision',
+        '-r',
+        '--revision',
         type=int,
         metavar='<n>',
-        help='Wiktionary revision ID (from permalink)'
+        help='Wiktionary revision ID (from permalink)',
     )
     parser.add_argument(
         '--compact',
         action='store_true',
-        help='List definitions for all parts of speech together'
+        help='List definitions for all parts of speech together',
     )
-    parser.add_argument(
-        '--json',
-        action='store_true',
-        help='Output as JSON'
-    )
+    parser.add_argument('--json', action='store_true', help='Output as JSON')
     args = parser.parse_args(args)
 
     console = rich.console.Console()

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -392,12 +392,15 @@ class Section(LanguageEntry):
 
     def to_dict(self) -> dict:
         if self.has_definitions():
-            return dict(
+            D = dict(
                 part_of_speech=self.part_of_speech,
                 word=self.word,
                 extras=self.lead_extras,
                 definitions=[d.to_dict() for d in self.definitions]
             )
+            if self.conjugation is not None:
+                D['conjugation'] = self.conjugation
+            return D
         else:
             return dict()
 

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -286,7 +286,7 @@ class Section(LanguageEntry):
     @property
     def _conjugation_table_tag(self) -> Optional[ConjugationTableTag]:
         headings = self.soup.find_all('h4')
-        candidate_table_headings = [h for h in headings if h.find(text='Conjugation')]
+        candidate_table_headings = [h for h in headings if h.find(string='Conjugation')]
         try:
             table_heading = candidate_table_headings[0]
         except IndexError:

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -27,6 +27,7 @@ class WordInfo:
     """
     Information about a word, including its language, part of speech, and definitions.
     """
+
     LANGUAGE = 'Spanish'
     entry: LanguageEntry
 
@@ -77,10 +78,7 @@ class WordInfo:
         Human-readable multiline string with word and all definitions listed
         one after one another
         """
-        definitions_with_bullet = [
-            f'- {d.to_str()}'
-            for d in self.entry.definitions
-        ]
+        definitions_with_bullet = [f'- {d.to_str()}' for d in self.entry.definitions]
         lines = [f'[bold yellow]{self.word}[/]'] + definitions_with_bullet
         return '\n'.join(lines)
 
@@ -97,7 +95,7 @@ class WordInfo:
         return dict(
             word=self.word,
             language=self.LANGUAGE,
-            definition_sections=[d.to_dict() for d in self.sections_with_definitions]
+            definition_sections=[d.to_dict() for d in self.sections_with_definitions],
         )
 
 
@@ -122,10 +120,7 @@ def _render_section_lead(ss: Section) -> str:
 [yellow]olvido[/], [italic]first-person singular preterite[/] [yellow]olvidé[/], \
 [italic]past participle[/] [yellow]olvidado[/])'
     """
-    parts = [
-        f'[italic]{ss.part_of_speech}:[/]',
-        f'[bold yellow]{ss.word}[/]'
-    ]
+    parts = [f'[italic]{ss.part_of_speech}:[/]', f'[bold yellow]{ss.word}[/]']
     if ss.gender:
         parts.append(ss.gender)
     if ss.lead_extras:
@@ -161,7 +156,9 @@ def _render_section_lead_extras(lead_extras: List[dict]) -> List[str]:
     lead_extra_strings = []
     for le in lead_extras:
         if 'value' in le:
-            lead_extra_strings.append(f'[italic]{le["attribute"]}[/] [yellow]{le["value"]}[/]')
+            lead_extra_strings.append(
+                f'[italic]{le["attribute"]}[/] [yellow]{le["value"]}[/]'
+            )
         else:
             lead_extra_strings.append(f'[italic]{le["attribute"]}[/]')
     return lead_extra_strings
@@ -174,12 +171,11 @@ class WiktionaryPage:
 
     Use `get_entry()` to extract a particular LanguageEntry object from the page.
     """
+
     word: str
     revision: Optional[int] = None
 
-    def __init__(self,
-                 word: str,
-                 revision: Optional[int] = None):
+    def __init__(self, word: str, revision: Optional[int] = None):
         """
         Initialize a WiktionaryPage object with a word and an optional revision number.
 
@@ -192,15 +188,16 @@ class WiktionaryPage:
         self.word = word
         self.revision = revision
         self.soup = BeautifulSoup(
-            markup=self.get_page_html(word, revision),
-            features='html.parser'
+            markup=self.get_page_html(word, revision), features='html.parser'
         )
 
     def __repr__(self):
         if self.revision is None:
             return f'{self.__class__.__name__}({self.word!r})'
         else:
-            return f'{self.__class__.__name__}({self.word!r}, revision={self.revision!r})'
+            return (
+                f'{self.__class__.__name__}({self.word!r}, revision={self.revision!r})'
+            )
 
     @staticmethod
     def get_page_html(word, revision=None):
@@ -260,12 +257,13 @@ class WiktionaryPage:
                 this Wiktionary page.
         """
         return LanguageEntry(
-            soup=_extract_language_entry_soup(self.soup, language=language),
-            page=self
+            soup=_extract_language_entry_soup(self.soup, language=language), page=self
         )
 
 
-def _extract_language_entry_soup(page_soup: BeautifulSoup, language: str) -> BeautifulSoup:
+def _extract_language_entry_soup(
+    page_soup: BeautifulSoup, language: str
+) -> BeautifulSoup:
     """
     Get a new BeautifulSoup object that only has the tags from the entry that matches
     `language`.
@@ -308,6 +306,7 @@ class LanguageEntry:
     >>> isinstance(entry, LanguageEntry)
     True
     """
+
     # TODO clear up the hierarchy and inheritance between LanguageEntry and Section.
 
     def __init__(self, soup: BeautifulSoup, page: WiktionaryPage):
@@ -325,10 +324,7 @@ class LanguageEntry:
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return NotImplemented
-        return (
-            self.page == other.page
-            and self.soup == other.soup
-        )
+        return self.page == other.page and self.soup == other.soup
 
     @property
     def sections(self) -> List[Section]:
@@ -380,7 +376,6 @@ Conjugation = dict
 
 
 class Section(LanguageEntry):
-
     def __init__(self, parent: LanguageEntry, soup: BeautifulSoup):
         self.parent = parent
         if not isinstance(parent, LanguageEntry) or isinstance(parent, Section):
@@ -396,7 +391,7 @@ class Section(LanguageEntry):
                 part_of_speech=self.part_of_speech,
                 word=self.word,
                 extras=self.lead_extras,
-                definitions=[d.to_dict() for d in self.definitions]
+                definitions=[d.to_dict() for d in self.definitions],
             )
             if self.conjugation is not None:
                 D['conjugation'] = self.conjugation
@@ -452,7 +447,9 @@ class Section(LanguageEntry):
         Extract attributes from inside parentheses on the lead line (after the word).
         """
         word_tag = self._word_tag
-        opening_parenthesis = word_tag.find_next_sibling(string=re.compile(r'\(')) or _EMPTY_TAG
+        opening_parenthesis = (
+            word_tag.find_next_sibling(string=re.compile(r'\(')) or _EMPTY_TAG
+        )
 
         # take attributes from <i> tags and corresponding values from the following <b> tag
         # TODO this seems quite fragile
@@ -471,9 +468,11 @@ class Section(LanguageEntry):
         Parse definitions from soup and return them as a list of strings.
         """
         return [
-            Definition(text=self.definition_list_item_to_str(definition_list_item),
-                       extras=None,
-                       section=self)
+            Definition(
+                text=self.definition_list_item_to_str(definition_list_item),
+                extras=None,
+                section=self,
+            )
             for definition_list_item in self._definition_list_items()
         ]
 
@@ -527,13 +526,20 @@ class ConjugationTable:
             'infinitive': self._parse_simple(self._ROW_INDEX_INFINITIVE),
             'gerund': self._parse_simple(self._ROW_INDEX_GERUND),
             'past participle': self._parse_complex(
-                self._ROW_SLICE_PAST_PARTICIPLE, header=('masculine', 'feminine')),
+                self._ROW_SLICE_PAST_PARTICIPLE, header=('masculine', 'feminine')
+            ),
             'indicative': self._parse_complex(
-                self._ROW_SLICE_INDICATIVE, header=('s1', 's2', 's3', 'pl1', 'pl2', 'pl3')),
+                self._ROW_SLICE_INDICATIVE,
+                header=('s1', 's2', 's3', 'pl1', 'pl2', 'pl3'),
+            ),
             'subjunctive': self._parse_complex(
-                self._ROW_SLICE_SUBJUNCTIVE, header=('s1', 's2', 's3', 'pl1', 'pl2', 'pl3')),
+                self._ROW_SLICE_SUBJUNCTIVE,
+                header=('s1', 's2', 's3', 'pl1', 'pl2', 'pl3'),
+            ),
             'imperative': self._parse_complex(
-                self._ROW_SLICE_IMPERATIVE, header=('s1', 's2', 's3', 'pl1', 'pl2', 'pl3')),
+                self._ROW_SLICE_IMPERATIVE,
+                header=('s1', 's2', 's3', 'pl1', 'pl2', 'pl3'),
+            ),
         }
 
     def _parse_simple(self, row_index: int):
@@ -571,7 +577,7 @@ class ConjugationTable:
         elif len(spans) > 1:
             return {
                 'tú': spans[0].get_text().strip(),
-                'vos': spans[1].get_text().strip()
+                'vos': spans[1].get_text().strip(),
             }
 
 

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from ctypes import Union
 import json
 
 import re
@@ -411,9 +412,16 @@ class ConjugationTable:
     def _parse_row(tr: bs4.Tag, header: Sequence[str]) -> Tuple[str, dict]:
         row_key = tr.th.get_text().strip()
         value_tags = [td for td in tr.find_all('td')]
-        values = [td.get_text().strip() for td in value_tags]
+        values = [ConjugationTable._parse_value_tag(td) for td in value_tags]
         values_dict = {h: v for h, v in zip(header, values)}
         return row_key, values_dict
+
+    @staticmethod
+    def _parse_value_tag(td: bs4.Tag) -> Union[str, dict, None]:
+        text = td.get_text().strip()
+        if text == '':
+            return None
+        return text
 
 
 @dataclass

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -94,10 +94,12 @@ def _render_section_lead(ss: Section) -> str:
 
 
 def _render_section_lead_extras(lead_extras: List[dict]) -> str:
-    lead_extra_strings = [
-        f'[italic]{le["attribute"]}[/] [yellow]{le["value"]}[/]'
-        for le in lead_extras
-    ]
+    lead_extra_strings = []
+    for le in lead_extras:
+        if 'value' in le:
+            lead_extra_strings.append(f'[italic]{le["attribute"]}[/] [yellow]{le["value"]}[/]')
+        else:
+            lead_extra_strings.append(f'[italic]{le["attribute"]}[/]')
     return ', '.join(lead_extra_strings)
 
 
@@ -307,6 +309,9 @@ class Section(LanguageEntry):
 
     @property
     def lead_extras(self) -> List[dict]:
+        """
+        Extract attributes from inside parentheses on the lead line (after the word).
+        """
         word_tag = self._word_tag
         opening_parenthesis = word_tag.find_next_sibling(string=re.compile(r'\(')) or _EMPTY_TAG
 
@@ -315,8 +320,10 @@ class Section(LanguageEntry):
         L = []
         for attribute_tag in opening_parenthesis.find_next_siblings('i'):
             value_tag = attribute_tag.find_next_sibling('b')
-            L.append({'attribute': attribute_tag.text,
-                      'value': value_tag.text})
+            D = {'attribute': attribute_tag.text}
+            if value_tag:  # only try to extract text if the value tab exists
+                D['value'] = value_tag.text
+            L.append(D)
         return L
 
     @property

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -418,10 +418,23 @@ class ConjugationTable:
 
     @staticmethod
     def _parse_value_tag(td: bs4.Tag) -> Union[str, dict, None]:
-        text = td.get_text().strip()
-        if text == '':
-            return None
-        return text
+        """
+        Parse a td tag containing one conjugation.
+
+        In the usual case, when the td contains one span, return the text inside it (or None if
+        the text is empty). In the tuteo/voseo case, the td contains 2 spans; their texts are
+        split in a dict.
+        """
+        spans = td.find_all('span')
+        if len(spans) == 1:
+            text = spans[0].get_text().strip() or None
+            return text
+        elif len(spans) > 1:
+            return {
+                'tú': spans[0].get_text().strip(),
+                'vos': spans[1].get_text().strip()
+            }
+
 
 
 @dataclass

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from ctypes import Union
 import json
 
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, Tuple, Type
+from typing import Any, List, Optional, Sequence, Tuple, Type, Union
 
 import requests
 import bs4
@@ -385,9 +384,9 @@ class Section(LanguageEntry):
     def __repr__(self):
         return f'<{self.parent.page} → {self.parent.title!r} → {self.title!r}>'
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         if self.has_definitions():
-            D = dict(
+            D: dict[str, Any] = dict(
                 part_of_speech=self.part_of_speech,
                 word=self.word,
                 extras=self.lead_extras,
@@ -579,6 +578,8 @@ class ConjugationTable:
                 'tú': spans[0].get_text().strip(),
                 'vos': spans[1].get_text().strip(),
             }
+        else:
+            return None
 
 
 @dataclass

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -3,7 +3,7 @@ import json
 
 import re
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Type
 
 import requests
 import bs4
@@ -234,6 +234,8 @@ class LanguageEntry:
 
 
 _EMPTY_TAG = bs4.Tag(name='empty')
+HtmlTable = Type[bs4.Tag]
+Conjugation = dict
 
 
 class Section(LanguageEntry):
@@ -273,6 +275,27 @@ class Section(LanguageEntry):
     @property
     def _lead_p(self) -> bs4.Tag:
         return self.soup.p or _EMPTY_TAG
+
+    @property
+    def conjugation(self) -> Optional[Conjugation]:
+        html_table = self._conjugation_html_table
+        if html_table is None:
+            return None
+        return self._conjugation_html_table_to_dict(html_table)
+
+    @property
+    def _conjugation_html_table(self) -> Optional[HtmlTable]:
+        headings = self.soup.find_all('h4')
+        candidate_table_headings = [h for h in headings if h.find(text='Conjugation')]
+        try:
+            table_heading = candidate_table_headings[0]
+        except IndexError:
+            return None
+        return table_heading.find_next('div', class_='NavFrame')
+
+    @staticmethod
+    def _conjugation_html_table_to_dict(html_table: HtmlTable) -> dict:
+        raise NotImplementedError
 
     # TODO write a specific test
     @property

--- a/palabras/core.py
+++ b/palabras/core.py
@@ -234,7 +234,7 @@ class LanguageEntry:
 
 
 _EMPTY_TAG = bs4.Tag(name='empty')
-HtmlTable = Type[bs4.Tag]
+ConjugationTableTag = Type[bs4.Tag]
 Conjugation = dict
 
 
@@ -278,13 +278,13 @@ class Section(LanguageEntry):
 
     @property
     def conjugation(self) -> Optional[Conjugation]:
-        html_table = self._conjugation_html_table
-        if html_table is None:
+        table_tag = self._conjugation_table_tag
+        if table_tag is None:
             return None
-        return self._conjugation_html_table_to_dict(html_table)
+        return self._conjugation_table_tag_to_dict(table_tag)
 
     @property
-    def _conjugation_html_table(self) -> Optional[HtmlTable]:
+    def _conjugation_table_tag(self) -> Optional[ConjugationTableTag]:
         headings = self.soup.find_all('h4')
         candidate_table_headings = [h for h in headings if h.find(text='Conjugation')]
         try:
@@ -294,7 +294,7 @@ class Section(LanguageEntry):
         return table_heading.find_next('div', class_='NavFrame')
 
     @staticmethod
-    def _conjugation_html_table_to_dict(html_table: HtmlTable) -> dict:
+    def _conjugation_table_tag_to_dict(html_table: ConjugationTableTag) -> dict:
         raise NotImplementedError
 
     # TODO write a specific test

--- a/palabras/utils.py
+++ b/palabras/utils.py
@@ -5,9 +5,7 @@ from bs4 import BeautifulSoup
 from bs4.element import PageElement
 
 
-def tags_to_soup(tags: Sequence[bs4.Tag],
-                 *,
-                 features='html.parser') -> BeautifulSoup:
+def tags_to_soup(tags: Sequence[bs4.Tag], *, features='html.parser') -> BeautifulSoup:
     """
     Given a list of tags, create a new BeautifulSoup object from those tags (copying tags to the
     new soup object in order)
@@ -25,15 +23,15 @@ def get_heading_siblings_on_level(element):
     """
     hierarchy = 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
     if element.name not in hierarchy:
-        raise ValueError(
-            f'Element with {element.name} (expected one of {hierarchy})')
+        raise ValueError(f'Element with {element.name} (expected one of {hierarchy})')
 
-    same_and_higher = hierarchy[:hierarchy.index(element.name) + 1]
+    same_and_higher = hierarchy[: hierarchy.index(element.name) + 1]
     return get_siblings_until(element, same_and_higher)
 
 
-def get_siblings_until(element: PageElement,
-                       until: Union[str, Container[str]]) -> List[PageElement]:
+def get_siblings_until(
+    element: PageElement, until: Union[str, Container[str]]
+) -> List[PageElement]:
     """
     Return a list of sibling elements until the next occurrence of a certain tag name (or
     list/tuple/etc. of tag names).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ envlist = py38
 
 [testenv]
 deps = -e .[test]
-commands = pytest --cov --cov-report=term-missing --doctest-modules
+commands = pytest
            mypy palabras --ignore-missing-imports
            flake8
 """
+
+[tool.pytest.ini_options]
+addopts = "--cov=palabras --cov-report=term-missing --doctest-modules"

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -487,3 +487,22 @@ def test_no_conjugation_for_noun():
 def test_verb_conjugation_is_dict():
     wi = WordInfo.from_search('olvidar')
     assert isinstance(wi.definition_sections[0].conjugation, dict)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('keys, expected', (
+    (['gerund'], 'olvidando'),
+    (['past participle', 'plural', 'feminine'], 'olvidadas'),
+    (['indicative', 'preterite', 'pl2'], 'olvidaréis'),
+    (['subjunctive', 'present', 's2'], {'tú': 'olvides', 'vos': 'olvidés'}),  # tuteo/voseo case
+    (['imperative', 'affirmative', 's1'], None),
+))
+def test_verb_conjugation_content(mocked_request_url_text, keys, expected):
+    wi = WordInfo.from_search('olvidar')
+    conjugation = wi.definition_sections[0].conjugation
+
+    # loop through keys and traverse the conjugation dict structure
+    item = conjugation
+    for key in keys:
+        item = item[key]
+    assert item == expected

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -47,6 +47,27 @@ def mocked_request_url_text(mocker: MockerFixture):
     mocker.patch('palabras.core.request_url_text', side_effect=lambda url: mock_cache[url])
 
 
+@pytest.mark.parametrize('args', [
+    ['-h'],
+    ['-V'],
+    ['olvidar'],
+    ['olvidar', '-r', '66217360'],
+    ['ene', '-r', '68912066'],
+])
+def test_main_exitcode_only(mocker, args):
+    """
+    Simulate calling the CLI with various sets of options and assert that the exitcode is 0.
+
+    If a call is found to cause an unexpected error, throw those parameters here, fix the error,
+    and we have a test to assert that it stays fixed.
+    """
+    mocker.patch('sys.argv', ['palabras'] + args)
+    with pytest.raises(SystemExit) as e:
+        # importing __main__ causes the script to be run
+        from palabras import __main__  # noqa: F401
+    assert e.value.code == 0
+
+
 def test_word_info_from_search_return_type(mocked_request_url_text):
     word = 'despacito'
     wi = WordInfo.from_search(word)
@@ -300,6 +321,7 @@ def test_main(capsys: pytest.CaptureFixture, mocker):
         Interjection: ¡hola!
         - hello, hi
     ''').lstrip()
+
 
 
 def test_get_next_siblings_until():

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -532,8 +532,7 @@ def test_verb_conjugation_is_dict():
     (['gerund'], 'olvidando'),
     (['past participle', 'plural', 'feminine'], 'olvidadas'),
     (['indicative', 'future', 'pl2'], 'olvidaréis'),
-    pytest.param(['subjunctive', 'present', 's2'], {'tú': 'olvides', 'vos': 'olvidés'},
-                 marks=pytest.mark.xfail()),  # tuteo/voseo case
+    (['subjunctive', 'present', 's2'], {'tú': 'olvides', 'vos': 'olvidés'}),  # tuteo/voseo case
     (['imperative', 'affirmative', 's1'], None),
 ))
 def test_verb_conjugation_content(mocked_request_url_text, keys, expected):

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -534,7 +534,7 @@ def test_verb_conjugation_is_dict():
     (['indicative', 'future', 'pl2'], 'olvidaréis'),
     pytest.param(['subjunctive', 'present', 's2'], {'tú': 'olvides', 'vos': 'olvidés'},
                  marks=pytest.mark.xfail()),  # tuteo/voseo case
-    pytest.param(['imperative', 'affirmative', 's1'], None, marks=pytest.mark.xfail()),
+    (['imperative', 'affirmative', 's1'], None),
 ))
 def test_verb_conjugation_content(mocked_request_url_text, keys, expected):
     wi = WordInfo.from_search('olvidar')

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -522,19 +522,19 @@ def test_no_conjugation_for_noun():
     assert wi.definition_sections[0].conjugation is None
 
 
-@pytest.mark.xfail
 def test_verb_conjugation_is_dict():
     wi = WordInfo.from_search('olvidar')
     assert isinstance(wi.definition_sections[0].conjugation, dict)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('keys, expected', (
+    (['infinitive'], 'olvidar'),
     (['gerund'], 'olvidando'),
     (['past participle', 'plural', 'feminine'], 'olvidadas'),
-    (['indicative', 'preterite', 'pl2'], 'olvidaréis'),
-    (['subjunctive', 'present', 's2'], {'tú': 'olvides', 'vos': 'olvidés'}),  # tuteo/voseo case
-    (['imperative', 'affirmative', 's1'], None),
+    (['indicative', 'future', 'pl2'], 'olvidaréis'),
+    pytest.param(['subjunctive', 'present', 's2'], {'tú': 'olvides', 'vos': 'olvidés'},
+                 marks=pytest.mark.xfail()),  # tuteo/voseo case
+    pytest.param(['imperative', 'affirmative', 's1'], None, marks=pytest.mark.xfail()),
 ))
 def test_verb_conjugation_content(mocked_request_url_text, keys, expected):
     wi = WordInfo.from_search('olvidar')

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -121,14 +121,14 @@ def test_get_wiktionary_page_contains_translation(mocked_request_url_text):
     word = 'culpar'
     translation = 'blame'
     page = palabras.core.WiktionaryPage(word)
-    assert translation in page
+    assert translation in str(page.soup)
 
 
 def test_wiktionary_page_contains_portuguese_conjugation(mocked_request_url_text):
     word = 'culpar'
     expected_contains = 'culpou'  # Portuguese 3rd person preterite
     page = palabras.core.WiktionaryPage(word)
-    assert expected_contains in page
+    assert expected_contains in str(page.soup)
 
 
 def test_spanish_entry_type(mocked_request_url_text):
@@ -147,7 +147,7 @@ def test_spanish_entry_does_not_contain_portuguese(mocked_request_url_text):
     word = 'culpar'
     portuguese_conjugation = 'culpou'  # Portuguese 3rd person preterite
     spanish_entry = WiktionaryPage(word).get_spanish_entry()
-    assert portuguese_conjugation not in spanish_entry
+    assert portuguese_conjugation not in str(spanish_entry.soup)
 
 
 # TODO remove?
@@ -321,7 +321,6 @@ def test_main(capsys: pytest.CaptureFixture, mocker):
         Interjection: ¡hola!
         - hello, hi
     ''').lstrip()
-
 
 
 def test_get_next_siblings_until():
@@ -519,12 +518,12 @@ def test_word_info_to_dict(mocked_request_url_text):
 
 def test_no_conjugation_for_noun():
     wi = WordInfo.from_search('palabra')
-    assert wi.definition_sections[0].conjugation is None
+    assert wi.sections_with_definitions[0].conjugation is None
 
 
 def test_verb_conjugation_is_dict():
     wi = WordInfo.from_search('olvidar')
-    assert isinstance(wi.definition_sections[0].conjugation, dict)
+    assert isinstance(wi.sections_with_definitions[0].conjugation, dict)
 
 
 @pytest.mark.parametrize('keys, expected', (
@@ -537,7 +536,7 @@ def test_verb_conjugation_is_dict():
 ))
 def test_verb_conjugation_content(mocked_request_url_text, keys, expected):
     wi = WordInfo.from_search('olvidar')
-    conjugation = wi.definition_sections[0].conjugation
+    conjugation = wi.sections_with_definitions[0].conjugation
 
     # loop through keys and traverse the conjugation dict structure
     item = conjugation

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -476,3 +476,14 @@ def test_minimal_section_empty_lead(mocker):
 def test_word_info_to_dict(mocked_request_url_text):
     wi = WordInfo.from_search('olvidar')
     assert wi.to_dict() == EXPECTED_DICT_OLVIDAR
+
+
+def test_no_conjugation_for_noun():
+    wi = WordInfo.from_search('palabra')
+    assert wi.definition_sections[0].conjugation is None
+
+
+@pytest.mark.xfail
+def test_verb_conjugation_is_dict():
+    wi = WordInfo.from_search('olvidar')
+    assert isinstance(wi.definition_sections[0].conjugation, dict)

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -14,6 +14,123 @@ from palabras.utils import get_siblings_until, get_heading_siblings_on_level
 
 MOCK_CACHE_FILE_PATH = Path(__file__).parent / '../data/mock_cache.json'
 
+EXPECTED_CONJUGATION_OLVIDAR = {
+    'infinitive': 'olvidar',
+    'gerund': 'olvidando',
+    'past participle': {
+        'singular': {
+            'masculine': 'olvidado',
+            'feminine': 'olvidada'
+        },
+        'plural': {
+            'masculine': 'olvidados',
+            'feminine': 'olvidadas'
+        }
+    },
+    'indicative': {
+        'present': {
+            's1': 'olvido',
+            's2': {
+                'tú': 'olvidas',
+                'vos': 'olvidás'
+            },
+            's3': 'olvida',
+            'pl1': 'olvidamos',
+            'pl2': 'olvidáis',
+            'pl3': 'olvidan'
+        },
+        'imperfect': {
+            's1': 'olvidaba',
+            's2': 'olvidabas',
+            's3': 'olvidaba',
+            'pl1': 'olvidábamos',
+            'pl2': 'olvidabais',
+            'pl3': 'olvidaban'
+        },
+        'preterite': {
+            's1': 'olvidé',
+            's2': 'olvidaste',
+            's3': 'olvidó',
+            'pl1': 'olvidamos',
+            'pl2': 'olvidasteis',
+            'pl3': 'olvidaron'
+        },
+        'future': {
+            's1': 'olvidaré',
+            's2': 'olvidarás',
+            's3': 'olvidará',
+            'pl1': 'olvidaremos',
+            'pl2': 'olvidaréis',
+            'pl3': 'olvidarán'
+        },
+        'conditional': {
+            's1': 'olvidaría',
+            's2': 'olvidarías',
+            's3': 'olvidaría',
+            'pl1': 'olvidaríamos',
+            'pl2': 'olvidaríais',
+            'pl3': 'olvidarían'
+        }
+    },
+    'subjunctive': {
+        'present': {
+            's1': 'olvide',
+            's2': {
+                'tú': 'olvides',
+                'vos': 'olvidés'
+            },
+            's3': 'olvide',
+            'pl1': 'olvidemos',
+            'pl2': 'olvidéis',
+            'pl3': 'olviden'
+        },
+        'imperfect(ra)': {
+            's1': 'olvidara',
+            's2': 'olvidaras',
+            's3': 'olvidara',
+            'pl1': 'olvidáramos',
+            'pl2': 'olvidarais',
+            'pl3': 'olvidaran'
+        },
+        'imperfect(se)': {
+            's1': 'olvidase',
+            's2': 'olvidases',
+            's3': 'olvidase',
+            'pl1': 'olvidásemos',
+            'pl2': 'olvidaseis',
+            'pl3': 'olvidasen'
+        },
+        'future1': {
+            's1': 'olvidare',
+            's2': 'olvidares',
+            's3': 'olvidare',
+            'pl1': 'olvidáremos',
+            'pl2': 'olvidareis',
+            'pl3': 'olvidaren'
+        }
+    },
+    'imperative': {
+        'affirmative': {
+            's1': None,
+            's2': {
+                'tú': 'olvida',
+                'vos': 'olvidá'
+            },
+            's3': 'olvide',
+            'pl1': 'olvidemos',
+            'pl2': 'olvidad',
+            'pl3': 'olviden'
+        },
+        'negative': {
+            's1': None,
+            's2': 'no olvides',
+            's3': 'no olvide',
+            'pl1': 'no olvidemos',
+            'pl2': 'no olvidéis',
+            'pl3': 'no olviden'
+        }
+    }
+}
 EXPECTED_DICT_OLVIDAR = dict(
     word='olvidar',
     language='Spanish',
@@ -30,7 +147,8 @@ EXPECTED_DICT_OLVIDAR = dict(
                 dict(text='(transitive) to forget (be forgotten by)'),
                 dict(text='(reflexive, intransitive) to forget, elude, escape'),
                 dict(text='(with de, reflexive, intransitive) to forget, to leave behind')
-            ]
+            ],
+            conjugation=EXPECTED_CONJUGATION_OLVIDAR
         )
     ]
 )

--- a/test/test_palabras.py
+++ b/test/test_palabras.py
@@ -285,6 +285,23 @@ def test_cli_no_spanish_entry(capsys: pytest.CaptureFixture, mocked_request_url_
     assert exitcode == 1
 
 
+def test_main(capsys: pytest.CaptureFixture, mocker):
+    """
+    A little bit more opaque setup to test if we get expected output also by running __main__.py
+    with mocked sys.argv
+    """
+    mocker.patch('sys.argv', ['palabras', 'hola'])  # mock cli arguments
+    with pytest.raises(SystemExit) as e:
+        # importing __main__ causes the script to be run
+        from palabras import __main__  # noqa: F401
+    assert e.value.code == 0  # check exitcode
+    captured = capsys.readouterr()
+    assert captured.out == dedent('''
+        Interjection: ¡hola!
+        - hello, hi
+    ''').lstrip()
+
+
 def test_get_next_siblings_until():
     markup = (
         '<h1>hello</h1>'


### PR DESCRIPTION
Parse conjugation from the table on verbs' Wiktionary pages. The conjugation is available in the json output, e.g. `palabras olvidar --json` (no nice table yet).